### PR TITLE
Improve footer accessibility by increasing color contrast and centralizing brand colors

### DIFF
--- a/source/stylesheets/datacite.scss
+++ b/source/stylesheets/datacite.scss
@@ -54,6 +54,7 @@ Datacite - Bootstrap 3 theme
 @import "node_modules/bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";
 
 // Globals
+@import 'shared/datacite_colors';
 @import "datacite/globals/colors";
 @import "datacite/globals/variables";
 @import "datacite/globals/mixins";

--- a/source/stylesheets/datacite/components/_footer.scss
+++ b/source/stylesheets/datacite/components/_footer.scss
@@ -8,7 +8,7 @@
   width: 100%;
   height: 340px;
   font-size: 16px;
-  color: $dark-gray;
+  color: $datacite-primary-dark-blue;
   background-color: $light-gray;
   padding: .75em 0;
   margin: 0;
@@ -23,7 +23,7 @@
     padding-left: 0;
   }
   a, a:hover, a:visited {
-    color: $dark-gray;
+    color: $datacite-primary-dark-blue;
   }
   h4.share {
     margin-bottom: .5em;
@@ -58,6 +58,6 @@
 
   .color-description {
     font-size: 18px;
-    color: $dark-gray;
+    color: $datacite-primary-dark-blue;
   }
 }

--- a/source/stylesheets/doi.scss
+++ b/source/stylesheets/doi.scss
@@ -54,6 +54,7 @@ Datacite - Bootstrap 3 theme
 @import "node_modules/bootstrap-sass/assets/stylesheets/bootstrap/responsive-utilities";
 
 // Globals
+@import 'shared/datacite_colors';
 @import "doi/globals/colors";
 @import "doi/globals/variables";
 @import "doi/globals/mixins";

--- a/source/stylesheets/doi/components/_footer.scss
+++ b/source/stylesheets/doi/components/_footer.scss
@@ -8,7 +8,7 @@
   width: 100%;
   height: 340px;
   font-size: 16px;
-  color: $dark-gray;
+  color: $datacite-primary-dark-blue;
   background-color: $lighter-gray;
   padding: .75em 0;
   margin: 0;
@@ -23,7 +23,7 @@
     padding-left: 0;
   }
   a, a:hover, a:visited {
-    color: $dark-gray;
+    color: $datacite-primary-dark-blue;
   }
   h4.share {
     margin-bottom: .5em;
@@ -58,6 +58,6 @@
 
   .color-description {
     font-size: 18px;
-    color: $dark-gray;
+    color: $datacite-primary-dark-blue;
   }
 }

--- a/source/stylesheets/homepage.scss
+++ b/source/stylesheets/homepage.scss
@@ -482,12 +482,12 @@ footer .container-fluid {
 }
 
 footer a {
-  color: #939CA2;
+  color: $datacite-primary-dark-blue;
   font-size: 14px;
 }
 
 footer h4 {
-  color: #939CA2;
+  color: $datacite-primary-dark-blue;
   font-size: 18px;
   font-weight: bold;
   margin-top: 15px;

--- a/source/stylesheets/homepage.scss
+++ b/source/stylesheets/homepage.scss
@@ -5,6 +5,7 @@
 @import 'application';
 
 /* Shared between homepage and blog. */
+@import 'shared/datacite_colors';
 @import 'shared/components/_mobile_cookie_bar';
 
 $lighter-gray:               #F4F5F5 !default;

--- a/source/stylesheets/shared/_datacite_colors.scss
+++ b/source/stylesheets/shared/_datacite_colors.scss
@@ -17,4 +17,4 @@ $datacite-lime:               #E2E254 !default;
 
 // Gradient endpoints (for backgrounds, infographics)
 $datacite-gradient-start:     $datacite-primary-light-blue !default;
-$datacite-gradient-end:       #243B53 !default;
+$datacite-gradient-end:       $datacite-primary-dark-blue !default;

--- a/source/stylesheets/shared/_datacite_colors.scss
+++ b/source/stylesheets/shared/_datacite_colors.scss
@@ -6,12 +6,13 @@ $datacite-primary-dark-blue:  #243B54 !default;
 $datacite-primary-light-blue: #00B1E2 !default;
 
 // Secondary colors (use in combination with primary dark blue)
-$datacite-secondary-grey:     #C0CED6 !default;
-$datacite-secondary-turquoise: #46BCAB !default;
-$datacite-secondary-light-red: #F07C73 !default;
+$datacite-secondary-grey:       #C0CED6 !default;
+$datacite-secondary-gray:       $datacite-secondary-grey !default;
+$datacite-secondary-turquoise:  #46BCAB !default;
+$datacite-secondary-light-red:  #F07C73 !default;
 
 // Additional colors
-$datacite-medium-blue:        #0D60D4 !default;
+$datacite-medium-blue:          #0D60D4 !default;
 $datacite-dark-pink:          #BC2B66 !default;
 $datacite-lime:               #E2E254 !default;
 

--- a/source/stylesheets/shared/_datacite_colors.scss
+++ b/source/stylesheets/shared/_datacite_colors.scss
@@ -1,0 +1,20 @@
+// DataCite Design Manual v2.1 - Brand Colors
+// https://datacite.org/wp-content/uploads/2024/06/DataCite_Design_manual-version_2_1.pdf
+
+// Primary colors
+$datacite-primary-dark-blue:  #243B54 !default;
+$datacite-primary-light-blue: #00B1E2 !default;
+
+// Secondary colors (use in combination with primary dark blue)
+$datacite-secondary-grey:     #C0CED6 !default;
+$datacite-secondary-turquoise: #46BCAB !default;
+$datacite-secondary-light-red: #F07C73 !default;
+
+// Additional colors
+$datacite-medium-blue:        #0D60D4 !default;
+$datacite-dark-pink:          #BC2B66 !default;
+$datacite-lime:               #E2E254 !default;
+
+// Gradient endpoints (for backgrounds, infographics)
+$datacite-gradient-start:     $datacite-primary-light-blue !default;
+$datacite-gradient-end:       #243B53 !default;


### PR DESCRIPTION
## Purpose

The primary goal of this PR is to increase color contrast within the application footers to improve accessibility and ensure compliance with design standards. 

## Approach

The approach involves replacing low-contrast grey tones with a darker, brand-approved blue. This change ensures that text and links are more readable against light background colors in the footer components.

### Key Modifications

- **New Asset**: Created `source/stylesheets/shared/_datacite_colors.scss` to centralize the DataCite Design Manual v2.1 brand colors.
- **Footer Updates**: Modified footer styles in `datacite.scss`, `doi.scss`, and `homepage.scss` to replace `$dark-gray` and hardcoded hex codes (#939CA2) with `$datacite-primary-dark-blue`.
- **Global Imports**: Included the shared brand color file in global stylesheet entry points to ensure the new variables are available.

### Important Technical Details

- Centralizing brand colors in a shared SCSS file prevents future hardcoding and makes it easier to manage theme updates across different parts of the platform (DataCite, DOI, and Homepage).
- Variables use the `!default` flag to allow for overrides if necessary without breaking the core theme.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.